### PR TITLE
delete empty line on upload csv

### DIFF
--- a/app/jobs/importer_base.rb
+++ b/app/jobs/importer_base.rb
@@ -50,8 +50,9 @@ class ImporterBase
         dests = data.map.with_index{ |row, line|
           # Switch from locale or custom to internal column name in case of csv
           row = yield(row, line + 1 + (options[:line_shift] || 0))
+          p "base import #{line}: #{row}, #{row.reject{|k, v| [:lat, :lng].include?(k)}.all?(&:nil?)}"
 
-          next if row.empty? # Skip empty line
+          next if row.reject{|k, v| [:lat, :lng].include?(k)}.all?(&:nil?)
 
           begin
             if (ref = uniq_ref(row))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1366,7 +1366,7 @@ en:
         string: text
         integer: integer
         float: '0.123'
-        date: 'm%-%d-%Y'
+        date: '%m-%d-%Y'
         date_desc: 'MM/DD/AAAA'
         hour: 'HH:MM'
         second: 'HH:MM:SS'


### PR DESCRIPTION
- row.empty? always return false, replace with excluding lat and lng (generated automatically so never empty hash) then checking emptiness
- find syntax error on locals en  "m%-%d-%Y" -> "%m-%d-%Y"